### PR TITLE
Formatting fix when extra spaces were added

### DIFF
--- a/lib/Format.js
+++ b/lib/Format.js
@@ -3,7 +3,9 @@ const Path = require("path");
 const FS   = require("fs");
 
 function FormatEntry(Ctx, Repository, Module, Method) {
-    const Params = (Ctx.Params || []).map(Par => [
+    const Params = (Ctx.Params || [])
+    .map(Par => Par.trim())
+    .map(Par => [
         Par.split(" ")[0].replace(/[\{\}]/g, ""),
         Par.split(" ")[1].replace("[", "").replace("]", "?"),
         Par.split(" ").slice(2).join(" ")
@@ -14,7 +16,7 @@ function FormatEntry(Ctx, Repository, Module, Method) {
 
     return [
         `## [.${Ctx.Value || (Ctx.Typedef || "").split(" ")[1] || ""}${Method ? `(${Params.map(Par => Par[1]).join(", ")})` : ""}](${Source})${FormalTags.length ? ` [${FormalTags.map(Tag => `**${Tag}**`).join(", ")}]` : ""}`,
-        `> ${Ctx.Description || ""}${Ctx.Flags.includes("ReadOnly") ? " [**Read Only**]" : ""}` + (Ctx.Params ? `\n> | Key | Type | Description |\n> | --- | --- | --- |\n${Params.map(Par => `> | ${Par[1]} | ${Par[0].replace(/\*/g, "Any")} | ${Par[2]} |`).join("\n")}` : ""),
+        `> ${Ctx.Description || ""}${Ctx.Flags.includes("ReadOnly") ? " [**Read Only**]" : ""}` + (Ctx.Params ? `\n> | Key | Type | Description |\n> | --- | --- | --- |\n${Params.map(Par => `> | ${Par[1]} | ${Par[0].replace(/\|/g, ", ").replace(/\*/g, "Any")} | ${Par[2]} |`).join("\n")}` : ""),
         `>\n> ${Ctx.Type ? `Type **${Ctx.Type}**` : (Ctx.Returns ? `Returns **${Ctx.Returns.split(" ")[0].replace(/\*/g, "Any")}** ${Ctx.Returns.split(" ").slice(1).join(" ")}` : (Ctx.Typedef ? `Type **${Ctx.Typedef.split(" ")[0]}**` : "Returns **{Null}**"))}`
     ].join("\n");
 }

--- a/lib/Format.js
+++ b/lib/Format.js
@@ -3,9 +3,7 @@ const Path = require("path");
 const FS   = require("fs");
 
 function FormatEntry(Ctx, Repository, Module, Method) {
-    const Params = (Ctx.Params || [])
-    .map(Par => Par.trim())
-    .map(Par => [
+    const Params = (Ctx.Params || []).map(Par => [
         Par.split(" ")[0].replace(/[\{\}]/g, ""),
         Par.split(" ")[1].replace("[", "").replace("]", "?"),
         Par.split(" ").slice(2).join(" ")

--- a/lib/Parse.js
+++ b/lib/Parse.js
@@ -21,7 +21,8 @@ module.exports = File => {
     return Comments.map(Comment => {
         return Comment
         .filter(Line => !["/**", "*/"].includes(Line))
-        .map(Line => Line.replace("* ", ""));
+        .map(Line => Line.replace("* ", ""))
+        .map(Line => Line.split(" ").map(Char => Char.trim()).join(" "));
     }).map(Tree => {
 
         const Line   = parseInt(Tree.pop()) + 1;


### PR DESCRIPTION
In the parser, I also added a little thing which splits the lines, trims each character and joins them back together. If you had two spaces, the formatter would mess up, but now it's not the case.

I also added a replace for `Object|Array` to `Object, Array`.

Resolves #2 