### PR TITLE
Added a constructor table to view parameters

### DIFF
--- a/Test/Documentations/Cube.md
+++ b/Test/Documentations/Cube.md
@@ -7,24 +7,32 @@
 * [Types](https://github.com/QSmally/Docgen/blob/master/Test/Documentations/Types.md)
 
 A basic Cube measure.
+```js
+const Cube = new Cube(5, 3);
+```
+
+> | Key | Type | Description |
+> | --- | --- | --- |
+> | x | Number | Length of this Cube. |
+> | z | Number | Width of this Cube. |
 
 To create your own, please create another class which extends this one.
 
 
 
 # Values
-## [.Length](https://github.com/QSmally/Docgen/blob/master/Test/lib/Cube.js#L13)
+## [.Length](https://github.com/QSmally/Docgen/blob/master/Test/lib/Cube.js#L14)
 > The length of this Cube. [**Read Only**]
 >
 > Type **{Number}**
 
-## [.Width](https://github.com/QSmally/Docgen/blob/master/Test/lib/Cube.js#L21)
+## [.Width](https://github.com/QSmally/Docgen/blob/master/Test/lib/Cube.js#L22)
 > The width of this Cube. [**Read Only**]
 >
 > Type **{Number}**
 
 # Methods
-## [.Square()](https://github.com/QSmally/Docgen/blob/master/Test/lib/Cube.js#L31) [**Async**]
+## [.Square()](https://github.com/QSmally/Docgen/blob/master/Test/lib/Cube.js#L32) [**Async**]
 > Calculates the surface of this Cube.
 >
 > Returns **{Number}** Area of the Cube.

--- a/Test/Documentations/CustomCube.md
+++ b/Test/Documentations/CustomCube.md
@@ -9,6 +9,11 @@
 
 Yet another custom Cube.
 
+> | Key | Type | Description |
+> | --- | --- | --- |
+> | x | Number | Length of this Cube. |
+> | z | Number | Width of this Cube. |
+
 
 
 # Values

--- a/Test/Documentations/MyCube.md
+++ b/Test/Documentations/MyCube.md
@@ -9,6 +9,12 @@
 
 My custom Cube.
 
+> | Key | Type | Description |
+> | --- | --- | --- |
+> | n | String | Name of this Cube. |
+> | x | Number | Length of this Cube. |
+> | z | Number | Width of this Cube. |
+
 
 
 # Values

--- a/Test/lib/Cube.js
+++ b/Test/lib/Cube.js
@@ -7,6 +7,7 @@ class Cube {
      * A basic Cube measure.
      * @param {Number} x Length of this Cube.
      * @param {Number} z Width of this Cube.
+     * @example const Cube = new Cube(5, 3);
      */
     constructor (x, y) {
         

--- a/lib/Format.js
+++ b/lib/Format.js
@@ -2,15 +2,18 @@
 const Path = require("path");
 const FS   = require("fs");
 
-function FormatEntry(Ctx, Repository, Module, Method) {
-    const Params = (Ctx.Params || []).map(Par => [
+function ParseParams(Params) {
+    return (Params || []).map(Par => [
         Par.split(" ")[0].replace(/[\{\}]/g, ""),
         Par.split(" ")[1].replace("[", "").replace("]", "?"),
         Par.split(" ").slice(2).join(" ")
     ]);
+}
 
+function FormatEntry(Ctx, Repository, Module, Method) {
     const FormalTags = Ctx.Flags.filter(Tag => ["Setter", "Getter", "Async"].includes(Tag));
     const Source     = Repository + Module + `#L${Ctx.Line}`;
+    const Params     = ParseParams(Ctx.Params);
 
     return [
         `## [.${Ctx.Value || (Ctx.Typedef || "").split(" ")[1] || ""}${Method ? `(${Params.map(Par => Par[1]).join(", ")})` : ""}](${Source})${FormalTags.length ? ` [${FormalTags.map(Tag => `**${Tag}**`).join(", ")}]` : ""}`,
@@ -18,6 +21,7 @@ function FormatEntry(Ctx, Repository, Module, Method) {
         `>\n> ${Ctx.Type ? `Type **${Ctx.Type}**` : (Ctx.Returns ? `Returns **${Ctx.Returns.split(" ")[0].replace(/\*/g, "Any")}** ${Ctx.Returns.split(" ").slice(1).join(" ")}` : (Ctx.Typedef ? `Type **${Ctx.Typedef.split(" ")[0]}**` : "Returns **{Null}**"))}`
     ].join("\n");
 }
+
 
 module.exports = (Files, Module, Tree, Conf) => {
 
@@ -51,7 +55,9 @@ module.exports = (Files, Module, Tree, Conf) => {
         (Conf.Index ? `* [Start](${Documentation + "Index.md"})\n` : "") + (Files.map(Module => `* [${Module}](${Documentation + `${Module}.md`})`).join("\n")),
 
         // Constructor information
-        (Constructor !== "Type Definitions" ? `${Constructor.Description}${Constructor.Code ? `\n\`\`\`js\n${Constructor.Code}\n\`\`\`` : ""}` : "") + (Conf.Additional[ModuleName] ? `\n\n${Conf.Additional[ModuleName]}` : ""),
+        (Constructor !== "Type Definitions" ? `${Constructor.Description}${Constructor.Code ? `\n\`\`\`js\n${Constructor.Code}\n\`\`\`` : ""}` : "") +
+        (Constructor !== "Type Definitions" && (Constructor.Params || []).length ? `\n\n> | Key | Type | Description |\n> | --- | --- | --- |\n${ParseParams(Constructor.Params).map(Par => `> | ${Par[1]} | ${Par[0].replace(/\|/g, ", ").replace(/\*/g, "Any")} | ${Par[2]} |`).join("\n")}` : "") +
+        (Conf.Additional[ModuleName] ? `\n\n${Conf.Additional[ModuleName]}` : ""),
 
         // Properties
         (Values.length ? `\n\n# Values\n` : "") + (Values.map(Element => FormatEntry(Element, Conf.Repository, Module, false)).join("\n\n")) +


### PR DESCRIPTION
I implemented a way to view the parameters needed for constructors, like in example `docs/Cube.md`. I, thereby, also added a function which parses the parameters for simplicity.

This PR indicates this package is ready for production.

Resolves #1 